### PR TITLE
Support for building on non-linux operating systems

### DIFF
--- a/config_generic_os.go
+++ b/config_generic_os.go
@@ -1,0 +1,15 @@
+//go:build !linux
+// +build !linux
+
+package zeroconfig
+
+import (
+	"fmt"
+	"io"
+)
+
+type SyslogConfig struct{}
+
+func (wc *WriterConfig) compileMainForOS() (io.Writer, error) {
+	return nil, fmt.Errorf("unknown writer type %q", wc.Type)
+}

--- a/config_linux.go
+++ b/config_linux.go
@@ -1,0 +1,50 @@
+package zeroconfig
+
+import (
+	"fmt"
+	"io"
+	"log/syslog"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/journald"
+)
+
+const (
+	// WriterTypeSyslog writes to the system logging service.
+	// The configuration is stored in the SyslogConfig struct.
+	WriterTypeSyslog WriterType = "syslog"
+	// WriterTypeSyslogCEE writes to the system logging service with MITRE CEE prefixes.
+	WriterTypeSyslogCEE WriterType = "syslog-cee"
+	// WriterTypeJournald writes to systemd's logging service.
+	WriterTypeJournald WriterType = "journald"
+)
+
+// SyslogConfig contains the configuration options for the syslog writer.
+//
+// See https://pkg.go.dev/log/syslog for exact details.
+type SyslogConfig struct {
+	// All parameters are passed to https://pkg.go.dev/log/syslog#Dial directly.
+	Network string          `json:"network,omitempty" yaml:"network,omitempty"`
+	Host    string          `json:"host,omitempty" yaml:"host,omitempty"`
+	Flags   syslog.Priority `json:"flags,omitempty" yaml:"flags,omitempty"`
+	Tag     string          `json:"tag,omitempty" yaml:"tag,omitempty"`
+}
+
+func (wc *WriterConfig) compileMainForOS() (io.Writer, error) {
+	switch wc.Type {
+	case WriterTypeSyslog, WriterTypeSyslogCEE:
+		sl, err := syslog.Dial(wc.Network, wc.Host, wc.Flags, wc.Tag)
+		if err != nil {
+			return nil, err
+		}
+		if wc.Type == WriterTypeSyslogCEE {
+			return zerolog.SyslogCEEWriter(sl), nil
+		} else {
+			return zerolog.SyslogLevelWriter(sl), nil
+		}
+	case WriterTypeJournald:
+		return journald.NewJournalDWriter(), nil
+	default:
+		return nil, fmt.Errorf("unknown writer type %q", wc.Type)
+	}
+}


### PR DESCRIPTION
Hello,

I'm working on https://github.com/42wim/matterbridge/pull/1864 which uses mautrix (great library by the way!).
In yet unreleased versions of mautrix, I the latter uses zeroconfig.

However zeroconfig does not compile on non-linux patforms.
While this is not problematic for myself, it means that matterbridge could not adopt mautrix because it is multiplatform.

This moves all linux-specific code to a dedicated file. Going further, it would probably be better to support syslog for all UNIX platforms and not only linux.
I will look into doing that if you think zeroconfig should be multiplatform-compatible.

What do you think?

